### PR TITLE
feat: Persist and restore `IDS_Logistics_isPlacedEntity`

### DIFF
--- a/Functions/fn_MissionLoad.sqf
+++ b/Functions/fn_MissionLoad.sqf
@@ -69,10 +69,12 @@ if (!isNil "_GetVariableStatic") then {
         private _posASL = _objectAttributes get "posASL";
         private _type = _objectAttributes get "type";
         private _dirAndUp = _objectAttributes get "vectorDirAndUp";
+        private _isPlacedEntity = _objectAttributes get "isPlacedEntity";
         
         private _newObject = createVehicle [_type, [0,0, (500 + random 2000)], [], 0, "CAN_COLLIDE"];
         _newObject setVectorDirAndUp _dirAndUp;
         _newObject setPosASL _posASL;
+        _newObject setVariable ["IDS_Logistics_isPlacedEntity", _isPlacedEntity, true];
     } forEach _allObjectNames;
 };
 

--- a/Functions/fn_MissionSave.sqf
+++ b/Functions/fn_MissionSave.sqf
@@ -189,6 +189,7 @@ private _FinalSaving = _SaveStatics arrayIntersect _SaveStatics;
 {
     private _ObjectDataHashEach = createHashMap;
     private _ObjectNameStr = str getPosASL _x + "_Obj";
+    private _isPlacedEntity = _x getVariable ["IDS_Logistics_isPlacedEntity", false];
     _x setVehicleVarName _ObjectNameStr;
     
     private _ObjectName = vehicleVarName _x;
@@ -196,6 +197,7 @@ private _FinalSaving = _SaveStatics arrayIntersect _SaveStatics;
     _ObjectDataHashEach set ["type", typeOf _x];
     _ObjectDataHashEach set ["posASL", getPosASL _x];
     _ObjectDataHashEach set ["vectorDirAndUp", [vectorDir _x, vectorUp _x]];
+    _ObjectDataHashEach set ["isPlacedEntity", _isPlacedEntity];
     
     _ObjectDataHash set [_ObjectName, _ObjectDataHashEach];
 } forEach _FinalSaving;


### PR DESCRIPTION
This commit adds the ability to persist and restore the `IDS_Logistics_isPlacedEntity` variable for static objects during mission save and load. This ensures that the state of placed entities is maintained across mission sessions.

The changes include:

-   Adding `isPlacedEntity` to the object data hash during save.
-   Setting the `IDS_Logistics_isPlacedEntity` variable on loaded objects during load.