### PR TITLE
feat: Use remoteExec for dynamic text

### DIFF
--- a/Functions/Utilities/fn_showDynamicText.sqf
+++ b/Functions/Utilities/fn_showDynamicText.sqf
@@ -21,4 +21,5 @@ if (typeName _text == "STRING") then {
 };
 
 // Use standard parameters for positioning
-[_text, true, nil, _duration, 0.7] spawn BIS_fnc_textTiles;
+// [_text, true, nil, _duration, 0.7] spawn BIS_fnc_textTiles;
+[_text, true, nil, _duration, 0.7] remoteExec ["BIS_fnc_textTiles", 0, true];


### PR DESCRIPTION
This commit changes the `fn_showDynamicText.sqf` function to use `remoteExec` for displaying dynamic text. This ensures that the text is displayed for all clients, improving consistency and visibility.