### PR TITLE
Fix: Improve vehicle persistence and add object alive …

### DIFF
--- a/Functions/fn_MissionLoad.sqf
+++ b/Functions/fn_MissionLoad.sqf
@@ -65,16 +65,18 @@ if (!isNil "_GetVariableStatic") then {
     private _allObjectNames = keys _GetVariableStatic;
     
     {
-        private _objectAttributes = _GetVariableStatic get _x;
-        private _posASL = _objectAttributes get "posASL";
-        private _type = _objectAttributes get "type";
-        private _dirAndUp = _objectAttributes get "vectorDirAndUp";
-        private _isPlacedEntity = _objectAttributes get "isPlacedEntity";
+        if (alive _x) then {
+            private _objectAttributes = _GetVariableStatic get _x;
+            private _posASL = _objectAttributes get "posASL";
+            private _type = _objectAttributes get "type";
+            private _dirAndUp = _objectAttributes get "vectorDirAndUp";
+            private _isPlacedEntity = _objectAttributes get "isPlacedEntity";
         
-        private _newObject = createVehicle [_type, [0,0, (500 + random 2000)], [], 0, "CAN_COLLIDE"];
-        _newObject setVectorDirAndUp _dirAndUp;
-        _newObject setPosASL _posASL;
-        _newObject setVariable ["IDS_Logistics_isPlacedEntity", _isPlacedEntity, true];
+            private _newObject = createVehicle [_type, [0,0, (500 + random 2000)], [], 0, "CAN_COLLIDE"];
+            _newObject setVectorDirAndUp _dirAndUp;
+            _newObject setPosASL _posASL;
+            _newObject setVariable ["IDS_Logistics_isPlacedEntity", _isPlacedEntity, true];
+        };
     } forEach _allObjectNames;
 };
 
@@ -88,10 +90,21 @@ private _allVehNames = keys _GetVariableVeh;
     private _posATL = _VehAtts get "posATL";
     private _Type = _VehAtts get "type";
     private _DirUp = _VehAtts get "vectorDirAndUp";
+    private _fuel = _VehAtts get "fuel";
+    private _damage = _VehAtts get "damage";
+    private _damages = _VehAtts get "damages";
 
     private _NewVeh = createVehicle [_Type, [0,0, (500 + random 2000)], [], 0, "CAN_COLLIDE"];
     _NewVeh setVectorDirAndUp _DirUp;
     _NewVeh setPosATL _posATL;
+    _NewVeh setFuel _fuel;
+    _NewVeh setDamage _damage;
+    
+    {
+        private _key = _x;
+        private _value = (_damages # 2) # _forEachIndex;
+        _NewVeh setHitPointDamage [_key, _value];
+    } forEach (_damages # 0);
 
     // private _vehicleConfig = configFile >> "CfgVehicles" >> typeOf _NewVeh;
     // private _crewType = [west, _vehicleConfig] call BIS_fnc_selectCrew;

--- a/Functions/fn_MissionSave.sqf
+++ b/Functions/fn_MissionSave.sqf
@@ -120,6 +120,9 @@ private _finalVehiclesToSave = _vehiclesToSave arrayIntersect _vehiclesToSave;
     
     _vehicleDataHashEach set ["type", typeOf _vehicle];
     _vehicleDataHashEach set ["posATL", getPosATL _vehicle];
+    _vehicleDataHashEach set ["fuel", fuel _vehicle];
+    _vehicleDataHashEach set ["damage", damage _vehicle];
+    _vehicleDataHashEach set ["damages", getAllHitPointsDamage _vehicle];
     _vehicleDataHashEach set ["vectorDirAndUp", [vectorDir _vehicle, vectorUp _vehicle]];
     
     _VehicleDataHash set [_vehicleName, _vehicleDataHashEach];
@@ -187,19 +190,22 @@ private _staticsSaving = _staticsNewAlive - _staticsTerrain;
 private _FinalSaving = _SaveStatics arrayIntersect _SaveStatics;
 
 {
-    private _ObjectDataHashEach = createHashMap;
-    private _ObjectNameStr = str getPosASL _x + "_Obj";
-    private _isPlacedEntity = _x getVariable ["IDS_Logistics_isPlacedEntity", false];
-    _x setVehicleVarName _ObjectNameStr;
+    if (alive _x) then {
+        private _ObjectDataHashEach = createHashMap;
+        private _ObjectNameStr = str getPosASL _x + "_Obj";
+        private _isPlacedEntity = _x getVariable ["IDS_Logistics_isPlacedEntity", false];
+        
+        _x setVehicleVarName _ObjectNameStr;
     
-    private _ObjectName = vehicleVarName _x;
+        private _ObjectName = vehicleVarName _x;
     
-    _ObjectDataHashEach set ["type", typeOf _x];
-    _ObjectDataHashEach set ["posASL", getPosASL _x];
-    _ObjectDataHashEach set ["vectorDirAndUp", [vectorDir _x, vectorUp _x]];
-    _ObjectDataHashEach set ["isPlacedEntity", _isPlacedEntity];
-    
-    _ObjectDataHash set [_ObjectName, _ObjectDataHashEach];
+        _ObjectDataHashEach set ["type", typeOf _x];
+        _ObjectDataHashEach set ["posASL", getPosASL _x];
+        _ObjectDataHashEach set ["vectorDirAndUp", [vectorDir _x, vectorUp _x]];
+        _ObjectDataHashEach set ["isPlacedEntity", _isPlacedEntity];
+
+        _ObjectDataHash set [_ObjectName, _ObjectDataHashEach];
+    };
 } forEach _FinalSaving;
 
 profileNamespace setVariable [_ObjectDataName, _ObjectDataHash];


### PR DESCRIPTION
…checks in fn_MissionLoad.sqf, fn_MissionSave.sqf

- Added alive checks when loading saved objects to prevent saving of destroyed entities
- Implemented complete vehicle state persistence (damage, hitpoint damages, fuel)
- Added code to properly restore individual hitpoint damages on vehicles
- Enhanced vehicle restoration process to maintain exact state between sessions
- Fixed vehicle damage application to ensure vehicles spawn in saved condition"