### PR TITLE
Implement objective dominance thread

### DIFF
--- a/CfgFunctions.hpp
+++ b/CfgFunctions.hpp
@@ -47,6 +47,8 @@ class FLO {
         class createVirtualCivilianPopulation {};
         class indexObjectives                 {};
         class indexVirtualObjectives          {};
+        class flipObjective                  {};
+        class monitorObjectiveDominance      {};
     };
 
     class Logistics {

--- a/Functions/Virtualization/fn_flipObjective.sqf
+++ b/Functions/Virtualization/fn_flipObjective.sqf
@@ -1,0 +1,44 @@
+/*
+ * Function: FLO_fnc_flipObjective
+ * Author: Frontline Operations Development Group
+ * Description:
+ *   Changes the owner of a virtual objective and updates its marker color.
+ *
+ * Arguments:
+ *   0: Objective ID <STRING>
+ *   1: New owner <SIDE>
+ *
+ * Returns: <BOOL> Success
+ *
+ * Example:
+ *   ["virtual_1", west] call FLO_fnc_flipObjective;
+ */
+
+params ["_objectiveId", "_newOwner"];
+
+if (isNil "FLO_Objectives") exitWith {false};
+
+private _obj = FLO_Objectives get _objectiveId;
+if (isNil "_obj") exitWith {false};
+
+_obj set ["owner", _newOwner];
+FLO_Objectives set [_objectiveId, _obj];
+
+private _pos = _obj get "position";
+private _radius = _obj get "radius";
+private _marker = format ["obj_%1", _objectiveId];
+if (getMarkerColor _marker == "") then {
+    createMarker [_marker, _pos];
+    _marker setMarkerShape "ELLIPSE";
+    _marker setMarkerSize [_radius, _radius];
+};
+
+private _color = switch (_newOwner) do {
+    case west: {"colorBLUFOR"};
+    case east: {"colorOPFOR"};
+    case resistance: {"ColorGUER"};
+    default {"ColorBlack"};
+};
+
+_marker setMarkerColor _color;
+true

--- a/Functions/Virtualization/fn_indexObjectives.sqf
+++ b/Functions/Virtualization/fn_indexObjectives.sqf
@@ -101,7 +101,8 @@ for "_i" from 0 to (count _allLocations - 1) do {
         ["structures", _allFound],
         ["structurePositions", _structurePositions],
         ["location", _loc],
-        ["locType", _locType]
+        ["locType", _locType],
+        ["owner", east]
     ];
     _allObjectives set [_locStr, _objData];
 };
@@ -131,6 +132,27 @@ publicVariable "FLO_Objectives";
 
 // Add virtual objectives for uncovered clusters (docks, industrial, etc.)
 [FLO_Objectives, FLO_Objectives_Debug, 100] call FLO_fnc_indexVirtualObjectives;
+
+// Create map markers for all objectives (including newly added virtual ones)
+_keys = keys FLO_Objectives;
+{
+    private _id = _x;
+    private _data = FLO_Objectives get _id;
+    private _pos = _data get "position";
+    private _radius = _data get "radius";
+    private _owner = _data getOrDefault ["owner", east];
+    private _marker = createMarker [format ["obj_%1", _id], _pos];
+    _marker setMarkerShape "ELLIPSE";
+    _marker setMarkerSize [_radius, _radius];
+    private _color = switch (_owner) do {
+        case west: {"colorBLUFOR"};
+        case east: {"colorOPFOR"};
+        case resistance: {"ColorGUER"};
+        default {"ColorBlack"};
+    };
+    _marker setMarkerColor _color;
+    _marker setMarkerAlpha 0.3;
+} forEach _keys;
 
 if (FLO_Objectives_Debug) then {
     for "_i" from 0 to (count _keys - 1) do {

--- a/Functions/Virtualization/fn_indexVirtualObjectives.sqf
+++ b/Functions/Virtualization/fn_indexVirtualObjectives.sqf
@@ -158,7 +158,8 @@ for "_i" from 0 to (count _clusters - 1) do {
         ["structures", _cluster],
         ["structurePositions", _structurePositions],
         ["location", objNull],
-        ["locType", "virtual"]
+        ["locType", "virtual"],
+        ["owner", east]
     ];
     _objectives set [_id, _objData];
     _newCount = _newCount + 1;

--- a/Functions/Virtualization/fn_monitorObjectiveDominance.sqf
+++ b/Functions/Virtualization/fn_monitorObjectiveDominance.sqf
@@ -1,0 +1,63 @@
+/*
+ * Function: FLO_fnc_monitorObjectiveDominance
+ * Author: Frontline Operations Development Group
+ * Description:
+ *   Continuously checks player presence at objectives and flips ownership
+ *   when one side holds dominance for a period of time.
+ *
+ * Arguments: None
+ *
+ * Example:
+ *   [] spawn FLO_fnc_monitorObjectiveDominance;
+ */
+
+if (!isServer) exitWith {};
+if (isNil "FLO_Objectives") exitWith {};
+
+private _captureTime = 60;      // seconds needed to capture
+private _checkInterval = 5;     // time between checks
+
+while {true} do {
+    if (isNil "FLO_Objectives") exitWith {};
+    {
+        private _id = _x;
+        private _data = FLO_Objectives get _id;
+        if (isNil "_data") then { continue }; 
+
+        private _pos = _data get "position";
+        private _radius = _data get "radius";
+        private _owner = _data getOrDefault ["owner", east];
+        private _progress = _data getOrDefault ["captureProgress", 0];
+
+        private _bluforCount = { alive _x && side _x isEqualTo west && (_x distance2D _pos < _radius) } count allUnits;
+        private _opforCount  = { alive _x && side _x isEqualTo east && (_x distance2D _pos < _radius) } count allUnits;
+
+        if (_bluforCount > _opforCount && _bluforCount > 0) then {
+            _progress = (_progress + _checkInterval) min _captureTime;
+        } else {
+            if (_opforCount > _bluforCount && _opforCount > 0) then {
+                _progress = (_progress - _checkInterval) max (-_captureTime);
+            } else {
+                if (_progress > 0) then { _progress = (_progress - _checkInterval) max 0 };
+                if (_progress < 0) then { _progress = (_progress + _checkInterval) min 0 };
+            };
+        };
+
+        if (_progress >= _captureTime && {_owner != west}) then {
+            [_id, west] call FLO_fnc_flipObjective;
+            _owner = west;
+            _progress = 0;
+        } else {
+            if (_progress <= -_captureTime && {_owner != east}) then {
+                [_id, east] call FLO_fnc_flipObjective;
+                _owner = east;
+                _progress = 0;
+            };
+        };
+
+        _data set ["captureProgress", _progress];
+        FLO_Objectives set [_id, _data];
+    } forEach (keys FLO_Objectives);
+
+    sleep _checkInterval;
+};

--- a/Scripts/Init/init_Markers.sqf
+++ b/Scripts/Init/init_Markers.sqf
@@ -7,5 +7,7 @@ _respawnMarker setMarkerAlpha 1;
 
 [] call FLO_fnc_indexObjectives;
 
+[] spawn FLO_fnc_monitorObjectiveDominance;
+
 MarLOCC = 1;
 publicVariable "MarLOCC";


### PR DESCRIPTION
## Summary
- track new objectives with an owner in `indexVirtualObjectives`
- monitor BLUFOR/OPFOR presence and flip objective ownership when dominated
- register the monitoring function and start it during marker initialization
