### PR TITLE
Use objective subtypes for virtual groups

### DIFF
--- a/CUSTOM_ENEMY_FACTION.sqf
+++ b/CUSTOM_ENEMY_FACTION.sqf
@@ -64,72 +64,45 @@ East_Units_Officers = ["I_officer_F"];
 
 /*
  * OPFOR Virtualization Objective Configuration
- * This section defines how many of each unit type should spawn at different objective types
- * These are the default settings that will be used by the virtualization system
-*/
-
-// Structure: [objective type, [[group type, count], [group type, count], ...]]
+ * This section defines how many of each unit type should spawn at different
+ * objective subtypes produced by the objective indexing system. Subtypes
+ * include "capital", "city", "village", "local", "marine" and "cluster".
+ *
+ * Structure: [objective subtype, [[group type, count], [group type, count], ...]]
+ */
 OPFOR_Objective_Groups = [
-    // Support objectives - mix of infantry and light vehicles
-    ["o_support", [
-        ["infantry", 3], 
-        ["motorized", 2]
-    ]],
-    
-    // Neutral support objectives - lighter security
-    ["n_support", [
-        ["infantry", 2], 
-        ["motorized", 1]
-    ]],
-    
-    // Installation objectives - mix of infantry and heavy vehicles
-    ["o_installation", [
-        ["infantry", 4], 
-        ["mechanized", 2],
+    // Capital objectives - highest concentration of defenders
+    ["capital", [
+        ["infantry", 5],
+        ["motorized", 2],
         ["armor", 1]
     ]],
-    
-    // Neutral installation objectives
-    ["n_installation", [
-        ["infantry", 3], 
-        ["mechanized", 1]
+
+    // Major cities
+    ["city", [
+        ["infantry", 4],
+        ["motorized", 1]
     ]],
-    
-    // Anti-air objectives - AA vehicles and infantry
-    ["o_antiair", [
-        ["infantry", 2],
-        ["motorized", 1],
-        ["air", 1]
+
+    // Villages
+    ["village", [
+        ["infantry", 2]
     ]],
-    
-    // Service objectives - light vehicles and infantry
-    ["o_service", [
-        ["infantry", 2],
-        ["motorized", 2]
+
+    // Small local objectives
+    ["local", [
+        ["infantry", 1]
     ]],
-    
-    // Power plant objectives - infantry defense
-    ["loc_Power", [
+
+    // Coastal or marine facilities
+    ["marine", [
         ["infantry", 3],
         ["motorized", 1]
     ]],
-    
-    // Ruins objectives - light infantry presence
-    ["loc_Ruin", [
-        ["infantry", 1]
-    ]],
-    
-    // Recon objectives - small infantry and light vehicles
-    ["o_recon", [
-        ["infantry", 2],
-        ["motorized", 1],
-        ["helicopter", 1]
-    ]],
-    
-    // Infantry objectives - heavier infantry presence
-    ["o_inf", [
-        ["infantry", 4],
-        ["motorized", 1]
+
+    // Automatically generated clusters
+    ["cluster", [
+        ["infantry", 2]
     ]]
 ];
 

--- a/Functions/Virtualization/README.md
+++ b/Functions/Virtualization/README.md
@@ -67,7 +67,10 @@ The virtualization system now integrates with the Pathfinding module, allowing v
 The system is configured through `CUSTOM_ENEMY_FACTION.sqf`, which defines:
 
 1. The unit types available for each group type
-2. How many of each group type should spawn at different objective types
+2. The `OPFOR_Objective_Groups` array specifying how many of each group type
+   should spawn for each objective **subtype** produced by `FLO_fnc_indexObjectives`
+   (e.g. `city`, `village`, `cluster`). This variable is required and no
+   fallback configuration is provided.
 3. The activation distance for virtualization
 
 ## Usage Example

--- a/Functions/Virtualization/fn_initializeObjectiveGroups.sqf
+++ b/Functions/Virtualization/fn_initializeObjectiveGroups.sqf
@@ -36,104 +36,51 @@ publicVariable "InitializationOG";
 
 ["VIRTUALIZATION", 3, "Initializing objective groups"] call FLO_fnc_log;
 
-// Define mapping of objective types to group configurations
-private _objectiveGroupConfig = createHashMapFromArray [
-    // Support objectives - mix of infantry and light vehicles
-    ["o_support", [
-        ["infantry", 3], 
-        ["motorized", 2]
-    ]],
-    
-    ["n_support", [
-        ["infantry", 2], 
-        ["motorized", 1]
-    ]],
-    
-    // Installation objectives - mix of infantry and heavy vehicles
-    ["o_installation", [
-        ["infantry", 4], 
-        ["mechanized", 2],
-        ["armor", 1]
-    ]],
-    
-    ["n_installation", [
-        ["infantry", 3], 
-        ["mechanized", 1]
-    ]],
-    
-    // Anti-air objectives - AA vehicles and infantry
-    ["o_antiair", [
-        ["infantry", 2],
-        ["motorized", 1],
-        ["air", 1]
-    ]],
-    
-    // Service objectives - light vehicles and infantry
-    ["o_service", [
-        ["infantry", 2],
-        ["motorized", 2]
-    ]],
-    
-    // Power plant objectives - infantry defense
-    ["loc_Power", [
-        ["infantry", 3],
-        ["motorized", 1]
-    ]],
-    
-    // Ruins objectives - light infantry presence
-    ["loc_Ruin", [
-        ["infantry", 1]
-    ]],
-    
-    // Recon objectives - small infantry and light vehicles
-    ["o_recon", [
-        ["infantry", 2],
-        ["motorized", 1],
-        ["helicopter", 1]
-    ]],
-    
-    // Infantry objectives - heavier infantry presence
-    ["o_inf", [
-        ["infantry", 4],
-        ["motorized", 1]
-    ]]
-];
+// Load objective group configuration directly from the faction settings
+private _objectiveGroupConfig = createHashMapFromArray OPFOR_Objective_Groups;
 
 // Track all created groups
 private _allCreatedGroups = [];
 
-// Get all markers
-private _allMarkers = allMapMarkers;
+// Verify objectives exist
+if (isNil "FLO_Objectives") exitWith {
+    ["VIRTUALIZATION", 2, "No objectives found for initialization"] call FLO_fnc_log;
+    InitializationOG = true;
+    publicVariable "InitializationOG";
+    true
+};
 
-// Process each marker that could be an objective
+private _allObjectives = keys FLO_Objectives;
+
+// Process each indexed objective
 {
-    private _marker = _x;
-    private _markerType = getMarkerType _marker;
-    private _position = getMarkerPos _marker;
-    
-    // Check if this marker type is defined in our configuration
-    if (_objectiveGroupConfig getOrDefault [_markerType, []] isNotEqualTo []) then {
-        ["VIRTUALIZATION", 3, format["Processing objective: %1 (Type: %2)", _marker, _markerType]] call FLO_fnc_log;
-        
-        // Get group configuration for this objective type
-        private _groupsToCreate = _objectiveGroupConfig get _markerType;
+    private _objId = _x;
+    private _objData = FLO_Objectives get _objId;
+    private _subtype = _objData getOrDefault ["subtype", ""];
+
+    // Check if this subtype is defined in our configuration
+    if (_objectiveGroupConfig getOrDefault [_subtype, []] isNotEqualTo []) then {
+        ["VIRTUALIZATION", 3, format["Processing objective: %1 (Subtype: %2)", _objId, _subtype]] call FLO_fnc_log;
+
+        // Get group configuration for this objective subtype
+        private _groupsToCreate = _objectiveGroupConfig get _subtype;
         private _objectiveGroups = [];
-        
+
         // Create virtual groups for this objective using distribution
         {
             _x params ["_groupType", "_count"];
-            
+
             // Distribute the groups around the objective
-            private _createdGroups = [_marker, _groupType, _count] call FLO_fnc_distributeVirtualGroups;
+            private _createdGroups = [_objId, _groupType, _count] call FLO_fnc_distributeVirtualGroups;
             _objectiveGroups append _createdGroups;
         } forEach _groupsToCreate;
-        
+
         // Add all created groups to tracking array
         _allCreatedGroups append _objectiveGroups;
-        
-        ["VIRTUALIZATION", 3, format["Created %1 virtual groups at objective %2", count _objectiveGroups, _marker]] call FLO_fnc_log;
+
+        ["VIRTUALIZATION", 3, format["Created %1 virtual groups at objective %2", count _objectiveGroups, _objId]] call FLO_fnc_log;
     };
-} forEach _allMarkers;
+} forEach _allObjectives;
 
 // After processing objectives, add civilian population to locations
 [] call FLO_fnc_createVirtualCivilianPopulation;


### PR DESCRIPTION
## Summary
- redefine `OPFOR_Objective_Groups` for objective subtypes
- initialize objective groups from indexed objectives rather than markers
- load objective group config only from faction configuration
- clarify that `OPFOR_Objective_Groups` is required in documentation
- simplify objective group config retrieval