### PR TITLE
Extend precision strike to rockets and guns

### DIFF
--- a/CfgFunctions.hpp
+++ b/CfgFunctions.hpp
@@ -15,6 +15,8 @@ class FLO {
         class artilleryAssetManager             {};
         class airAssetManager                   {};
         class requestVirtualArtillery           {};
+        class precisionStrike                   {};
+        class selectAirMission                  {};
         class airTaskOrder                      {};
         class aiCommander                       {};
         class aiCommanderUnitCapabilityAnalyzer {};

--- a/Functions/AI/README.md
+++ b/Functions/AI/README.md
@@ -117,11 +117,28 @@ private _result = _mgr call ["_requestAirAsset", [getPos player]];
 ### Air Tasking Order System
 The ATO system allows the commander to queue multiple CAS or strike missions.
 Queued tasks are processed using the air asset manager and will only assign aircraft that already exist in the virtualization system.
+Mission types `"CAS"`, `"BOMB"`, and `"LASER"` are supported. All three use the
+precision strike routine to fire the aircraft's configured ordnance.
+`"CAS"` performs a rocket or cannon run, `"BOMB"` drops conventional bombs and
+`"LASER"` fires laser guided missiles. Laser strikes create a temporary
+`LaserTargetE` attached to the nearest enemy unit or vehicle so guided missiles
+track accurately; the marker is removed once the ordnance detonates.
+If no altitude is specified, the commander will use 300&nbsp;m for strike
+missions and 150&nbsp;m for CAS. When the mission parameter is omitted,
+the commander evaluates the target area: tanks result in a laser guided
+strike, any other vehicles or large infantry groups prompt a bombing run,
+otherwise close air support is used.
 
 ```sqf
 private _commander = call FLO_fnc_aiCommander;
-// Queue a laser guided strike at the player's position
-_commander call ["_callAirSupport", [getPos player, "STRIKE", "", 300]];
+// Let the commander decide the best mission type
+_commander call ["_callAirSupport", [getPos player]];
+// Request close air support explicitly
+_commander call ["_callAirSupport", [getPos player, "CAS"]];
+// Queue a laser guided strike
+_commander call ["_callAirSupport", [getPos player, "LASER"]];
+// Queue a precision bombing run
+_commander call ["_callAirSupport", [getPosATL player, "BOMB"]];
 ```
 
 ### Customizing Vehicle Selection

--- a/Functions/AI/fn_aiCommander.sqf
+++ b/Functions/AI/fn_aiCommander.sqf
@@ -409,8 +409,50 @@ private _aiCommander = createHashMapObject [[
         _success
     }],
 
+    ["_selectAirMission", {
+        params ["_self", "_targetPos"];
+
+        private _rad = 300;
+
+        // Look for enemy vehicles around the target
+        private _veh = vehicles select {
+            side _x == west && alive _x && { _x distance2D _targetPos < _rad }
+        };
+        private _tanks = _veh select { _x isKindOf "Tank" };
+
+        if (count _tanks > 0) exitWith {"LASER"};
+        if (count _veh > 0) exitWith {"BOMB"};
+
+        // Count infantry not inside vehicles
+        private _inf = allUnits select {
+            side _x == west && alive _x && { _x distance2D _targetPos < _rad } &&
+            { vehicle _x == _x }
+        };
+        if (count _inf > 10) exitWith {"BOMB"};
+
+        "CAS"
+    }],
+
     ["_callAirSupport", {
-        params ["_self", "_targetPos", ["_mission", "CAS"], ["_type", ""], ["_alt", 150]];
+        /*
+            Queues a mission for the Air Tasking Order. Mission types can be
+            "CAS", "BOMB" or "LASER". CAS missions perform a rocket or cannon
+            strafe while the strike missions drop bombs or fire laser guided
+            missiles. If the mission is empty the commander selects an
+            appropriate type based on nearby enemy vehicles. If no altitude is
+            provided the function defaults to 300 metres for strike missions and
+            150 metres for CAS.
+        */
+        params ["_self", "_targetPos", ["_mission", ""], ["_type", ""], ["_alt", -1]];
+
+        if (_mission isEqualTo "") then {
+            _mission = _self call ["_selectAirMission", [_targetPos]];
+        };
+
+        if (_alt < 0) then {
+            _alt = if (_mission in ["BOMB", "LASER"]) then {300} else {150};
+        };
+
         private _ato = _self get "_airTaskOrder";
         _ato call ["_addTask", [_targetPos, _mission, _type, _alt]];
     }],

--- a/Functions/AI/fn_airTaskOrder.sqf
+++ b/Functions/AI/fn_airTaskOrder.sqf
@@ -47,10 +47,14 @@ if (isNil "FLO_airTaskOrder") then {
                 };
 
                 if (!isNull _air) then {
-                    private _wp = _grp addWaypoint [_pos, 0];
-                    _wp setWaypointType "SAD";
-                    _wp setWaypointBehaviour "COMBAT";
-                    _wp setWaypointCombatMode "RED";
+                    if (_mission in ["BOMB", "LASER", "CAS"]) then {
+                        [_air, _pos, _mission, _alt] spawn FLO_fnc_precisionStrike;
+                    } else {
+                        private _wp = _grp addWaypoint [_pos, 0];
+                        _wp setWaypointType "SAD";
+                        _wp setWaypointBehaviour "COMBAT";
+                        _wp setWaypointCombatMode "RED";
+                    };
                     [_air, time + 300, _gid] spawn {
                         params ["_a", "_t", "_gid"];
                         waitUntil {sleep 5; time > _t || !alive _a};

--- a/Functions/AI/fn_precisionStrike.sqf
+++ b/Functions/AI/fn_precisionStrike.sqf
@@ -1,0 +1,140 @@
+/*
+    Function: FLO_fnc_precisionStrike
+
+    Description:
+        Orders an aircraft to execute a precision strike on a target position.
+        A suitable weapon is selected from the aircraft loadout using
+        <https://community.bistudio.com/wiki/getPylonMagazines>. Bombs,
+        rockets, missiles or the cannon can be used. The ordnance is spawned
+        directly under the aircraft similar to the Antistasi
+        "fn_airbomb.sqf" example so the attack is visibly executed by the
+        aircraft. Spent pylons are cleared with
+        <https://community.bistudio.com/wiki/setPylonLoadOut>.
+
+    Parameters:
+        _aircraft - Aircraft object executing the strike [Object]
+        _targetPos - Target position [Array]
+        _mission - Mission type ("CAS", "BOMB" or "LASER") [String]
+        _altitude - Desired flight altitude [Number]
+
+    Returns:
+        Boolean - True if ordnance was released
+*/
+
+params [
+    ["_aircraft", objNull, [objNull]],
+    ["_targetPos", [0,0,0], [[]], [3]],
+    ["_mission", "BOMB", [""]],
+    ["_altitude", 300, [0]]
+];
+
+if (isNull _aircraft) exitWith {false};
+
+private _missionUC = toUpper _mission;
+private _mags = getPylonMagazines _aircraft;
+
+private _selectedMag = "";
+private _isGun = false;
+
+{
+    private _mag = _x;
+    if (_mag isEqualTo "") then {continue};
+    private _ammo = getText (configFile >> "CfgMagazines" >> _mag >> "ammo");
+    private _sim  = toLower getText (configFile >> "CfgAmmo" >> _ammo >> "simulation");
+
+    switch (_missionUC) do {
+        case "LASER": {
+            private _laser = getNumber (configFile >> "CfgAmmo" >> _ammo >> "laserLock") == 1;
+            if (_sim find "missile" >= 0 && _laser) exitWith { _selectedMag = _mag };
+        };
+        case "BOMB": {
+            if (_sim find "bomb" >= 0) exitWith { _selectedMag = _mag };
+        };
+        case "CAS": {
+            if (_sim find "rocket" >= 0 || (_sim find "missile" >= 0 && getNumber (configFile >> "CfgAmmo" >> _ammo >> "laserLock") == 0)) exitWith { _selectedMag = _mag };
+        };
+    };
+} forEach _mags;
+
+if (_missionUC == "CAS" && _selectedMag isEqualTo "") then {
+    {
+        private _weaponMags = getArray (configFile >> "CfgWeapons" >> _x >> "magazines");
+        if (count _weaponMags > 0) exitWith {
+            _selectedMag = _weaponMags select 0;
+            _isGun = true;
+        };
+    } forEach weapons _aircraft;
+};
+
+if (_selectedMag isEqualTo "") exitWith {false};
+
+private _ammo     = getText (configFile >> "CfgMagazines" >> _selectedMag >> "ammo");
+private _bombCnt  = getNumber (configFile >> "CfgMagazines" >> _selectedMag >> "count");
+private _pIndex   = (_mags find _selectedMag) + 1; // pylon index for removal
+if (_bombCnt <= 0) then { _bombCnt = 1; };
+
+_aircraft flyInHeight _altitude;
+_aircraft doMove _targetPos;
+
+waitUntil { sleep 1; !alive _aircraft || (_aircraft distance2D _targetPos) < 200 };
+
+if (!alive _aircraft) exitWith {false};
+
+private _runLength = 250;
+private _speedMS   = (speed _aircraft) / 3.6;
+private _timeStep  = (_runLength / _bombCnt / _speedMS) max 0.1;
+
+private _laserTarget = objNull;
+
+if (_missionUC == "LASER") then {
+    private _target = objNull;
+    private _candidates = vehicles + allUnits;
+    private _near = _candidates select {
+        side _x == west && alive _x && { _x distance2D _targetPos < 25 }
+    };
+    if (count _near > 0) then {
+        _near sort true; // nearest first
+        _target = _near select 0;
+    };
+
+    if (!isNull _target) then {
+        _laserTarget = "LaserTargetE" createVehicle [0,0,0];
+        _laserTarget attachTo [_target, [0,0,0]];
+    } else {
+        _laserTarget = "LaserTargetE" createVehicle _targetPos;
+    };
+
+    private _missile = _ammo createVehicle (getPosASL _aircraft);
+    _missile setMissileTarget _laserTarget;
+    _missile setDir (getDir _aircraft);
+    _missile setShotParents [_aircraft, driver _aircraft];
+    _missile setVelocityModelSpace [0,60,0];
+    if (_pIndex > 0) then { _aircraft setPylonLoadOut [_pIndex, "", true]; };
+    [_laserTarget, _missile] spawn {
+        params ["_t", "_m"];
+        waitUntil { sleep 0.5; isNull _m || !alive _m };
+        deleteVehicle _t;
+    };
+} else {
+    sleep (_timeStep / 2);
+    for "_i" from 1 to _bombCnt do {
+        if (!alive _aircraft) exitWith {};
+        private _bombPos = (getPosATL _aircraft) vectorAdd [0,0,-5];
+        private _proj = _ammo createVehicle _bombPos;
+        _proj setDir (getDir _aircraft);
+        if (_isGun) then {
+            _proj setVelocityModelSpace [0,500,0];
+        } else {
+            if (_missionUC == "CAS") then {
+                _proj setVelocityModelSpace [0,120,0];
+            } else {
+                _proj setVelocity [0,0,-50];
+            };
+        };
+        _proj setShotParents [_aircraft, driver _aircraft];
+        sleep _timeStep;
+    };
+    if (_pIndex > 0 && !_isGun) then { _aircraft setPylonLoadOut [_pIndex, "", true]; };
+};
+
+true


### PR DESCRIPTION
## Summary
- Introduce Precision Control over Air Assets
- Allows Air Assets to be a lot more controllable for the AI Commander (so Arma 3 AI doesn't mess it up)
- Allow Aircraft to use BOMBS, LASER GUIDED WEAPONS, and More reliably.