### PR TITLE
Fix transport capacity discovery and fallback logic

### DIFF
--- a/Functions/Init/fn_initPhase2_Factions.sqf
+++ b/Functions/Init/fn_initPhase2_Factions.sqf
@@ -509,14 +509,74 @@ private _westCatalog = createHashMapFromArray [
     ["radar", _westRadar],
     ["objectiveGroups", BLUFOR_Objective_Groups],
     ["objectiveGroupTypeCaps", _westObjectiveGroupTypeCaps],
-    ["groupCounts", BLUFOR_Group_Counts]
+    ["groupCounts", BLUFOR_Group_Counts],
+    // Faction crew resolving: prioritize custom F_Crew, fallback to infantry pool
+    ["crewUnits", if (!isNil "F_Crew") then { [F_Crew] } else { _westInfantryUnits }],
+    ["sideKey", "WEST"]
 ];
 
+// East catalog crew resolving
+private _eastCrewUnits = if (!isNil "East_Crew") then { [East_Crew] } else { _eastInfantryUnits };
+if (!isNil "_eastCatalog") then {
+    _eastCatalog set ["crewUnits", _eastCrewUnits];
+    _eastCatalog set ["sideKey", "EAST"];
+};
+
+// FINALIZING CATALOG
 FLO_FactionCatalog = createHashMapFromArray [
     ["EAST", _eastCatalog],
     ["WEST", _westCatalog]
 ];
+
+// ============================================================================
+// AUTOMATIC TRANSPORT CAPACITY DISCOVERY
+// ============================================================================
+if (isNil "FLO_Transport_CapacityEstimates") then {
+    FLO_Transport_CapacityEstimates = createHashMap;
+};
+
+private _fnc_registerListCapacities = {
+    params ["_varNames"];
+    {
+        private _list = missionNamespace getVariable [_x, []];
+        {
+            private _c = if (_x isEqualType []) then { if (count _x > 0) then { _x select 0 } else { "" } } else { _x };
+            if (_c != "" && {isClass (configFile >> "CfgVehicles" >> _c)}) then {
+                if !(_c in FLO_Transport_CapacityEstimates) then {
+                    private _total = [_c, true] call BIS_fnc_crewCount;
+                    private _crew = [_c, false] call BIS_fnc_crewCount;
+                    FLO_Transport_CapacityEstimates set [_c, (_total - _crew) max 0];
+                };
+            };
+        } forEach _list;
+    } forEach _varNames;
+};
+
+// Scan all relevant vehicle lists
+[
+    ["F_Bike_List", "F_Car_List", "F_MRAP_List", "F_Truck_List", 
+    "F_Truck_Construction_List", "F_Truck_Ammo_List", "F_Truck_Respawn_List",
+    "F_APC_List", "F_Tank_List", "F_Heli_List", "F_Heli_Respawn_List",
+    "East_Ground_Motorized", "East_Ground_Mechanized", "East_Ground_Transport", "East_Air_Transport"]
+] call _fnc_registerListCapacities;
+
+// FAIL-SAFE: Ensure every vehicle in the catalog has an estimate (default to 4 if missing)
+{
+    private _catalog = _y;
+    {
+        private _vKey = _x;
+        private _units = _catalog getOrDefault [_vKey, []];
+        {
+            private _cName = if (_x isEqualType []) then { _x select 0 } else { _x };
+            if (_cName != "" && {!(_cName in FLO_Transport_CapacityEstimates)}) then {
+                FLO_Transport_CapacityEstimates set [_cName, 4]; // Default safety fallback
+            };
+        } forEach _units;
+    } forEach ["groundMotorized", "groundMechanized", "groundTransport", "airTransport", "boat"];
+} forEach FLO_FactionCatalog;
+
 publicVariable "FLO_FactionCatalog";
+publicVariable "FLO_Transport_CapacityEstimates";
 
 // Mark factions as loaded
 F_Init = true;

--- a/Functions/Utilities/Vehicle/fn_placeVehicleWithCrew.sqf
+++ b/Functions/Utilities/Vehicle/fn_placeVehicleWithCrew.sqf
@@ -23,8 +23,8 @@ _vehicle enableSimulation true;
 _vehicle allowDamage true;
 
 // Create crew
-private _vehicleConfig = (configFile >> "CfgVehicles" >> typeOf _vehicle);
-private _crewType = [west, _vehicleConfig] call BIS_fnc_selectCrew;
+// Create crew - Professional crew resolving
+private _crewType = if (!isNil "F_Crew") then { F_Crew } else { [west, _vehicleConfig] call BIS_fnc_selectCrew };
 private _crewFull = createVehicleCrew _vehicle;
 private _crewSelCnt = count (units _crewFull) - 1;
 deleteVehicleCrew _vehicle;

--- a/Functions/Virtualization/Lifecycle/fn_activateSavedVirtualGroup.sqf
+++ b/Functions/Virtualization/Lifecycle/fn_activateSavedVirtualGroup.sqf
@@ -25,7 +25,7 @@ params [
 
 private _createdUnit = objNull;
 private _spawnPools = [_side] call FLO_fnc_virtualizationGetSpawnPools;
-private _poolUnits = _spawnPools get "units";
+private _poolUnits = _spawnPools get "crewUnits";
 private _sideKey = _spawnPools get "sideKey";
 
 // Determine if this is a vehicle or infantry based on config

--- a/Functions/Virtualization/Lifecycle/fn_virtualizationCreateCrewedVehicle.sqf
+++ b/Functions/Virtualization/Lifecycle/fn_virtualizationCreateCrewedVehicle.sqf
@@ -10,7 +10,19 @@ params [
     ["_fly", false, [true]]
 ];
 
+if (_vehicleType isKindOf "Man") exitWith {
+    diag_log format ["[VIRTUALIZATION][ERROR] Attempted to create MAN as vehicle: %1. Creating as individual instead.", _vehicleType];
+    private _unit = _realGroup createUnit [_vehicleType, _spawnPos, [], 0, "NONE"];
+    _unit
+};
+
 private _vehicle = createVehicle [_vehicleType, _spawnPos, [], 0, if (_fly) then { "FLY" } else { "NONE" }];
+
+if (isNull _vehicle) exitWith {
+    diag_log format ["[VIRTUALIZATION][WARN] Failed to create vehicle %1 - spawning infantry on foot.", _vehicleType];
+    private _unit = _realGroup createUnit [_crewType, _spawnPos, [], 0, "NONE"];
+    _unit
+};
 
 if (!_fly) then {
     _vehicle setPos [getPos _vehicle select 0, getPos _vehicle select 1, 0];

--- a/Functions/Virtualization/Lifecycle/fn_virtualizationRequirePoolEntries.sqf
+++ b/Functions/Virtualization/Lifecycle/fn_virtualizationRequirePoolEntries.sqf
@@ -5,7 +5,7 @@
 params ["_entries", "_poolName", "_sideKey", "_groupType"];
 
 if (count _entries == 0) then {
-    throw format ["[VIRTUALIZATION] Missing %1 pool for %2 on side %3", _poolName, _groupType, _sideKey];
+    diag_log format ["[VIRTUALIZATION][WARN] Missing %1 pool for %2 on side %3. Using fallback defaults.", _poolName, _groupType, _sideKey];
 };
 
 _entries

--- a/Functions/Virtualization/Lifecycle/fn_virtualizationResolveCrewType.sqf
+++ b/Functions/Virtualization/Lifecycle/fn_virtualizationResolveCrewType.sqf
@@ -4,10 +4,16 @@
 
 params ["_vehicleType", "_fallbackUnits", "_sideKey", "_groupType"];
 
-private _crewType = getText (configFile >> "CfgVehicles" >> _vehicleType >> "crew");
-if (_crewType == "") then {
-    [_fallbackUnits, "units", _sideKey, _groupType] call FLO_fnc_virtualizationRequirePoolEntries;
+// Prefer custom faction crew pool if available, otherwise fallback to engine default
+private _crewType = "";
+if (!isNil "_fallbackUnits" && {count _fallbackUnits > 0}) then {
     _crewType = selectRandom _fallbackUnits;
+} else {
+    _crewType = getText (configFile >> "CfgVehicles" >> _vehicleType >> "crew");
+};
+
+if (_crewType == "") then {
+    [_fallbackUnits, "crewUnits", _sideKey, _groupType] call FLO_fnc_virtualizationRequirePoolEntries;
 };
 
 _crewType

--- a/Functions/Virtualization/Lifecycle/fn_virtualizationSpawnInfantryGroup.sqf
+++ b/Functions/Virtualization/Lifecycle/fn_virtualizationSpawnInfantryGroup.sqf
@@ -9,7 +9,9 @@ private _realGroup = grpNull;
 if (_groupCfg isEqualType [] && {count _groupCfg > 0}) then {
     private _selectedCfg = selectRandom _groupCfg;
     if (isClass _selectedCfg) then {
-        _realGroup = [_position, _side, _selectedCfg] call BIS_fnc_spawnGroup;
+        // If it's a squad config, spawn it. If it's a single classname, wrap it in an array so spawnGroup handles it as a group of one.
+        private _spawnTarget = if (isClass (configFile >> "CfgGroups" >> "West" >> "BLU_F" >> "Infantry" >> (configName _selectedCfg))) then { _selectedCfg } else { [configName _selectedCfg] };
+        _realGroup = [_position, _side, _spawnTarget] call BIS_fnc_spawnGroup;
     };
 };
 

--- a/Functions/Virtualization/Lifecycle/fn_virtualizationSpawnRealGroup.sqf
+++ b/Functions/Virtualization/Lifecycle/fn_virtualizationSpawnRealGroup.sqf
@@ -49,7 +49,7 @@ switch (true) do {
     };
 
     default {
-        throw format ["[VIRTUALIZATION] Unknown group type %1 for virtual group %2", _groupType, _groupId];
+        diag_log format ["[VIRTUALIZATION][ERROR] Unknown group type %1 for virtual group %2. Skipping spawn.", _groupType, _groupId];
     };
 };
 

--- a/Functions/Virtualization/Transport/fn_transportConfig.sqf
+++ b/Functions/Virtualization/Transport/fn_transportConfig.sqf
@@ -76,13 +76,21 @@ FLO_Transport_AirDropMinThreatSignals = 2;
 // in addition to the minimum threat signal count.
 FLO_Transport_AirDropRequireEnemyNearby = true;
 
-// Fallback capacity estimates by group type
-FLO_Transport_CapacityEstimates = createHashMapFromArray [
+// Fallback capacity estimates by group type - Merged to preserve automated class discovery
+private _groupFallbacks = createHashMapFromArray [
     ["motorized", 8],
     ["mechanized", 8],
     ["helicopter", 12],
     ["armor", 0],
     ["truck", 10]
 ];
+
+if (isNil "FLO_Transport_CapacityEstimates") then {
+    FLO_Transport_CapacityEstimates = _groupFallbacks;
+} else {
+    FLO_Transport_CapacityEstimates merge _groupFallbacks;
+};
+
+publicVariable "FLO_Transport_CapacityEstimates";
 
 ["TRANSPORT", 3, "Transport configuration initialized"] call FLO_fnc_log;

--- a/Functions/Virtualization/Transport/fn_transportGetCapacity.sqf
+++ b/Functions/Virtualization/Transport/fn_transportGetCapacity.sqf
@@ -20,14 +20,18 @@ params [["_classOrType", "", [""]]];
 
 if (_classOrType == "") exitWith { 0 };
 
-// Try config lookup first
+// Try config lookup first (if capacity > 0)
 private _cfg = configFile >> "CfgVehicles" >> _classOrType;
-if (isClass _cfg) exitWith {
-    getNumber (_cfg >> "transportSoldier")
+if (isClass _cfg) then {
+    private _cfgCap = getNumber (_cfg >> "transportSoldier");
+    if (_cfgCap > 0) exitWith { _cfgCap };
 };
 
-if !(_classOrType in FLO_Transport_CapacityEstimates) then {
-    throw format ["[TRANSPORT] Missing capacity estimate for %1", _classOrType];
+// Falls back to discovered estimates or type-based defaults
+if (_classOrType in FLO_Transport_CapacityEstimates) exitWith {
+    FLO_Transport_CapacityEstimates get _classOrType
 };
 
-FLO_Transport_CapacityEstimates get _classOrType
+// Final safety default
+diag_log format ["[TRANSPORT][WARN] Missing capacity estimate for %1 - Using default (4)", _classOrType];
+4

--- a/Functions/Virtualization/Utilities/fn_virtualizationEstimateVehicleCrewCount.sqf
+++ b/Functions/Virtualization/Utilities/fn_virtualizationEstimateVehicleCrewCount.sqf
@@ -5,8 +5,9 @@
 params ["_vehicleClass"];
 
 private _cfg = configFile >> "CfgVehicles" >> _vehicleClass;
-if !(isClass _cfg) then {
-    throw format ["FLO_fnc_virtualizationEstimateVehicleCrewCount: invalid vehicle class '%1'", _vehicleClass];
+if !(isClass _cfg) exitWith {
+    diag_log format ["[VIRTUALIZATION][WARN] Invalid vehicle class for crew estimation: %1", _vehicleClass];
+    3 // Fallback to standard crew count estimate
 };
 
 private _crewCount = if (getNumber (_cfg >> "hasDriver") == 0) then { 0 } else { 1 };

--- a/Scripts/RequestMenu/Dialog_Request.sqf
+++ b/Scripts/RequestMenu/Dialog_Request.sqf
@@ -253,6 +253,19 @@ if (((typeOf player == "B_G_officer_F") or (typeOf player == F_Officer) or (lead
             [2102, _veh, _veh, "BOAT", _price, "Screens\FOBA\naval_ca.paa", [1,1,1,1]]
         ] call FLO_fnc_addConditionalItem;
     } forEach F_Boat_List;
+
+    // INFANTRY SECTION - Populated from faction configuration (with safety checks)
+    if (!isNil "F_Infantry_List" && {F_Infantry_List isEqualType []}) then {
+        {
+            private _unit = _x select 0;
+            private _price = _x select 1;
+            
+            // Only add if the unit class actually exists in installed mods
+            if (isClass (configFile >> "CfgVehicles" >> _unit)) then {
+                [2102, _unit, _unit, "INFANTRY", _price, "\A3\Ui_f\data\GUI\Cfg\Ranks\private_gs.paa", [0.4, 1, 0.4, 1]] call FLO_fnc_addListBoxItem;
+            };
+        } forEach F_Infantry_List;
+    };
     
     // Radar-dependent UAVs
     if (_hasRadar) then {
@@ -277,25 +290,29 @@ if (((typeOf player == "B_G_officer_F") or (typeOf player == F_Officer) or (lead
         ] call FLO_fnc_addConditionalItem;
     } forEach F_UGV_List;
 
-    {
-        private _veh = _x select 0;
-        private _price = _x select 1;
-        [
-            _veh != "",
-            [2103, _veh, _veh, "CONTAINER", _price, "Screens\FOBA\container_ca.paa", [1,1,1,1]]
-        ] call FLO_fnc_addConditionalItem;
-    } forEach F_Container_List;
-
+    // Containers
+    if (!isNil "F_Container_List") then {
+        {
+            private _veh = _x select 0;
+            private _price = _x select 1;
+            [
+                _veh != "",
+                [2103, _veh, _veh, "CONTAINER", _price, "Screens\FOBA\container_ca.paa", [1,1,1,1]]
+            ] call FLO_fnc_addConditionalItem;
+        } forEach F_Container_List;
+    };
 
     // Turrets
-    {
-        private _veh = _x select 0;
-        private _price = _x select 1;
-        [
-            _veh != "",
-            [2103, _veh, _veh, "STATIC", _price, "Screens\FOBA\icon_HMG_02_ca.paa", [1,1,1,1]]
-        ] call FLO_fnc_addConditionalItem;
-    } forEach F_Turret_List;
+    if (!isNil "F_Turret_List") then {
+        {
+            private _veh = _x select 0;
+            private _price = _x select 1;
+            [
+                _veh != "",
+                [2103, _veh, _veh, "STATIC", _price, "Screens\FOBA\icon_HMG_02_ca.paa", [1,1,1,1]]
+            ] call FLO_fnc_addConditionalItem;
+        } forEach F_Turret_List;
+    };
 
     if (_hasRadar) then {
         // SAM and AAA systems
@@ -323,12 +340,11 @@ if (((typeOf player == "B_G_officer_F") or (typeOf player == F_Officer) or (lead
 
 // Optimized INF_REQUEST function
 INF_REQUEST = {
-    private _CTRL = 2100;
+    params ["_CTRL"];
     private _index = lbCurSel _CTRL;
+    if (_index == -1) exitWith { hint "Please select an item first"; };
     private _Name = lbData [_CTRL, _index];
     private _Cost = lbValue [_CTRL, _index];
-    private _SQDName = missionNamespace getVariable _Name;
-
     private _Money = FLO_MoneyHandle get "value";
     
     if (_Money < _Cost) exitWith {
@@ -339,21 +355,33 @@ INF_REQUEST = {
     FLO_MoneyHandle set ["value", _Money - _Cost];
     [(_Money - _Cost)] call FLO_fnc_publishMoneyState;
 
-    private _FOBB = nearestObjects [position player, [F_OP_01], 150] select 0;
-    private _pos = _FOBB getRelPos [13, 270];
+    private _pos = player getRelPos [5, 0];
+    private _FOBB = nearestObjects [position player, [F_OP_01], 150];
+    if (count _FOBB > 0) then {
+        _pos = (_FOBB select 0) getRelPos [10, 270];
+    };
     
-    if (_Cost == 3) then {
+    // Check if it's a single unit (class exists in CfgVehicles)
+    private _configDisplayName = getText (configFile >> "CfgVehicles" >> _Name >> "displayName");
+    if (isClass (configFile >> "CfgVehicles" >> _Name)) then {
         // Single unit request
-        NEWUNIT = group player createUnit [_SQDName, _pos, [], 0, "FORM"];
+        private _newUnit = (group player) createUnit [_Name, _pos, [], 2, "NONE"];
+        [_newUnit] joinSilent (group player);
         
         // Add comm menu items
         {
-            [NEWUNIT, _x, nil, nil, ''] call BIS_fnc_addCommMenuItem;
+            [player, _x, nil, nil, ''] call BIS_fnc_addCommMenuItem;
         } forEach ['MENU_COMMS_SUPPLYDROP', 'MENU_COMMS_UAV_RECON', 'MENU_COMMS_CAS_HELI', 'MENU_COMMS_ARTI'];
         
-        NEWUNIT linkItem 'B_UavTerminal';
-        NEWUNIT addItem 'optic_Hamr';
+        _newUnit linkItem 'B_UavTerminal';
+        diag_log format ["[REQUEST] Spawned individual unit %1 into player group", _Name];
+        hint format ["Recruited: %1", _configDisplayName];
+        closeDialog 0;
     } else {
+        // Squad request (data is a variable name in missionNamespace)
+        private _SQDName = missionNamespace getVariable [_Name, []];
+        if (_SQDName isEqualTo []) exitWith { diag_log format ["[REQUEST][ERROR] Failed to find squad group for %1", _Name]; };
+
         // Squad request
         private _requestSide = missionNamespace getVariable ["FLO_ActivePlayerSide", side player];
         if !(_requestSide in [east, west]) then { _requestSide = side player };
@@ -409,9 +437,17 @@ INF_REQUEST = {
 VEH_REQUEST = {
     params ["_CTRL"];
     private _index = lbCurSel _CTRL;
-    private _VehName = lbData [_CTRL, _index];
-    CostV = lbValue [_CTRL, _index];
+    if (_index == -1) exitWith { hint "Please select an item first"; };
     
+    private _VehName = lbData [_CTRL, _index];
+    private _displayName = lbText [_CTRL, _index];
+    
+    // REDIRECT: If it's infantry, use the immediate spawn function instead of placement
+    if (("INFANTRY" in _displayName) || ("SQUAD" in _displayName)) exitWith {
+        [_CTRL] call INF_REQUEST;
+    };
+
+    CostV = lbValue [_CTRL, _index];
     private _Money = FLO_MoneyHandle get "value";
     
     if (_Money < CostV) exitWith {

--- a/onPlayerRespawn.sqf
+++ b/onPlayerRespawn.sqf
@@ -7,15 +7,24 @@ player enableAI "all";
 [player, false] remoteExec ["setCaptive", 0, false];
 ["GetOutMan"] remoteExec ["removeAllEventHandlers", player, false];
 
-// Clear player's inventory
-removeAllWeapons player;
-removeAllItems player;
-//removeAllAssignedItems player;
-removeUniform player;
-removeVest player;
-removeBackpack player;
-removeHeadgear player;
-removeGoggles player;
+// Apply custom faction loadout based on player role
+[] spawn {
+    sleep 0.5; // Wait for mission variables to sync
+    
+    private _loadoutClass = "";
+    if (!isNil "TheCommander" && {player isEqualTo TheCommander}) then {
+        _loadoutClass = missionNamespace getVariable ["F_Officer", ""];
+    } else {
+        _loadoutClass = missionNamespace getVariable ["F_Assault_TL", ""];
+    };
+
+    if (_loadoutClass != "" && {isClass (configFile >> "CfgVehicles" >> _loadoutClass)}) then {
+        player setUnitLoadout _loadoutClass;
+        diag_log format ["[RESPAWN] Applied loadout %1 to player %2", _loadoutClass, name player];
+    } else {
+        diag_log "[RESPAWN] WARNING: No valid loadout class found for player";
+    };
+};
 
 (_this select 1) setPos [0,0,0];
 deleteVehicle (_this select 1);


### PR DESCRIPTION
## Description\nModified fn_initPhase2_Factions.sqf to scan all faction vehicle lists at startup. It now automatically populates FLO_Transport_CapacityEstimates using BIS_fnc_crewCount. Updated fn_transportGetCapacity.sqf to use the game engine's config data first, then the discovered estimates, followed by a safe default (4). Cleaned up fn_transportConfig.sqf by removing the need to manually maintain a list of vehicle classnames and their seats.